### PR TITLE
PowerVR kernel oops workaround

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+n9xx-ti-omap3-sgx (1.4.269) unstable; urgency=medium
+
+  * Fix kernel module oops
+
+ -- Arthur D. <spinal.by@gmail.com>  Tue, 15 Jan 2019 02:08:24 +0300
+
 n9xx-ti-omap3-sgx (1.4.268) unstable; urgency=medium
 
   * Initial release

--- a/debian/postinst
+++ b/debian/postinst
@@ -4,5 +4,5 @@
 rc-update add powervr sysinit
 
 if [ "$DEB_HOST_ARCH" = armhf ]; then
-	ln -s /lib/ld-linux-armhf.so.3 /lib/ld-linux.so.3
+	ln -svnf /lib/ld-linux-armhf.so.3 /lib/ld-linux.so.3
 fi

--- a/debian/ti-omap3-sgx.powervr.init
+++ b/debian/ti-omap3-sgx.powervr.init
@@ -8,6 +8,10 @@ depend() {
 }
 
 start() {
+    # Fix kernel oops by locking cpu frequency
+    # https://github.com/maemo-leste/bugtracker/issues/212
+    GOVERNOR=$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor)
+    echo performance > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
     ebegin "Modprobing pvrsrvkm"
     modprobe pvrsrvkm
     sleep 2
@@ -20,6 +24,7 @@ start() {
     ebegin "Changing permissions"
     chown root:video /dev/pvrsrvkm
     chmod 660 /dev/pvrsrvkm
+    echo $GOVERNOR > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 }
 
 stop() {


### PR DESCRIPTION
Fix PowerVR kernel module oops
Should close:
https://github.com/maemo-leste/bugtracker/issues/85
https://github.com/maemo-leste/bugtracker/issues/125

Temporary workaround for:
https://github.com/maemo-leste/bugtracker/issues/212